### PR TITLE
Resolve build error in image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,32 @@
-FROM debian:wheezy
+FROM debian:buster
 MAINTAINER Emre Bastuz <info@hml.io>
 
 # Environment
+ENV DEBIAN_FRONTEND noninteractive
 ENV LANG C.UTF-8
 ENV LANGUAGE C.UTF-8
 ENV LC_ALL C.UTF-8
 
 # Get current
-RUN apt-get update -y
-RUN apt-get dist-upgrade -y
+RUN apt-get update -y && apt-get dist-upgrade -y
 
-# Install packages 
-RUN apt-get install -y wget
-RUN apt-get install -y apache2
+# Install packages
+RUN apt-get install -y wget apache2 libtinfo5
 
 # Install vulnerable bash version from wayback/snapshot archive
 RUN wget http://snapshot.debian.org/archive/debian/20130101T091755Z/pool/main/b/bash/bash_4.2%2Bdfsg-0.1_amd64.deb -O /tmp/bash_4.2+dfsg-0.1_amd64.deb && \
  dpkg -i /tmp/bash_4.2+dfsg-0.1_amd64.deb
 
-ENV DEBIAN_FRONTEND noninteractive
 
 # Setup vulnerable web content
-ADD index.html /var/www/
+ADD index.html /var/www/html/
 ADD stats /usr/lib/cgi-bin/
-RUN chown www-data:www-data /usr/lib/cgi-bin/stats
-RUN chmod u+x /usr/lib/cgi-bin/stats
+RUN cd /etc/apache2/mods-enabled && ln -s ../mods-available/cgi.load
+RUN chown www-data:www-data /usr/lib/cgi-bin/stats && \
+ chmod u+x /usr/lib/cgi-bin/stats
 
-# Clean up 
-RUN apt-get autoremove
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# Clean up
+RUN apt-get autoremove && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Expose the port for usage with the docker -P switch
 EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Vulnerability as a Service - CVE 2014-6271
-A Debian (Wheezy) Linux system with a vulnerable version of bash and a web application to showcase CVS-2014-6271, a.k.a. Shellshock.
+A Debian (Buster) Linux system with a vulnerable version of bash and a web application to showcase CVS-2014-6271, a.k.a. Shellshock.
 
 # Overview
-This docker container is based on Debian Wheezy and has been modified to use a vulernable version of Bash (bash_4.2:2b:dfsg-0.1).
+This docker container is based on Debian Buster and has been modified to use a vulernable version of Bash (bash_4.2:2b:dfsg-0.1).
 
 A web application is available via Apache 2 and serves a CGI script which runs shell commands.
 


### PR DESCRIPTION
 Change docker image from wheezy to buster

Due to the removal of Wheezy and Jessie from mirrors (see https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html), the docker fail to download installations packages. So I change the image from wheezy to buster. In addiction that's correct others vulnerability you can detect during your vuln scan.

Also other minor changes:
 - Default apache2 index.html is now in /var/www/html, not /var/www/
 - I move cgi mods in available module (no activated by default)
 - In debian buster bash 4.2+dfsg-0.1 had a pre-dependency problem, I have to install libtinfo5.
 - Docker deployment time optimization (all installed package in one apt command... etc.)
 - Update image name in the README.md file.